### PR TITLE
Add Windows packaging instructions

### DIFF
--- a/horary78-main/README.md
+++ b/horary78-main/README.md
@@ -19,3 +19,29 @@ docker run -p 5000:5000 horary-app
 ```
 
 The API will be available on `http://localhost:5000`.
+
+## Windows Packaging
+
+If you want to distribute the application through the Microsoft Store you can
+wrap the backend executable and built frontend into an `.appx` package.
+
+1. **Build the executable**
+
+   Use PyInstaller to generate a standalone binary:
+
+   ```bash
+   pyinstaller --onefile backend/app.py
+   ```
+
+   The resulting `app.exe` will be placed in the `dist/` directory.
+
+2. **Create the `.appx` package**
+
+   After building the frontend (e.g. `npm run build`), use Microsoft's MSIX
+   Packaging Tool or `makeappx.exe` to combine `dist/app.exe` and the frontend
+   `dist/` folder into a single `.appx` file.
+
+3. **Sign and upload**
+
+   Sign the package with your code signing certificate and submit it to the
+   Microsoft Store for distribution.


### PR DESCRIPTION
## Summary
- document how to produce a Windows executable using PyInstaller
- explain how to bundle the app into an `.appx` with MSIX Packaging Tool or `makeappx.exe`
- cover signing and publishing to the Microsoft Store

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684527182178832483329849400f4ec0